### PR TITLE
UI Fix: Set title text color to black for Learn More section (Issue #38)

### DIFF
--- a/src/views/ShopifyInstall.vue
+++ b/src/views/ShopifyInstall.vue
@@ -431,6 +431,17 @@ ion-list {
   max-width: 375px;
 }
 
+@media (prefers-color-scheme: dark) {
+  .ion-item-button {
+    --color: var(--ion-color-dark-contrast);
+  }
+
+  .ion-item-button ion-icon,
+  .ion-item-button ion-label {
+    color: var(--ion-color-dark-contrast);
+  }
+}
+
 .ion-item-button::part(native) {
   background-color: #F5F6F9;
   border-radius: 20px;

--- a/src/views/ShopifyInstall.vue
+++ b/src/views/ShopifyInstall.vue
@@ -430,18 +430,7 @@ export default defineComponent({
 ion-list {
   max-width: 375px;
 }
-
-@media (prefers-color-scheme: dark) {
-  .ion-item-button {
-    --color: var(--ion-color-dark-contrast);
-  }
-
-  .ion-item-button ion-icon,
-  .ion-item-button ion-label {
-    color: var(--ion-color-dark-contrast);
-  }
-}
-
+  
 .ion-item-button::part(native) {
   background-color: #F5F6F9;
   border-radius: 20px;
@@ -454,5 +443,13 @@ ion-list {
 
 a {
   text-decoration: none;
+}
+  
+@media (prefers-color-scheme: dark) {
+  
+  .ion-item-button ion-icon,
+  .ion-item-button ion-label {
+    color: var(--ion-color-dark-contrast);
+  }
 }
 </style>


### PR DESCRIPTION
### Description
This PR fixes a UI readability bug in the "Learn More" section at the bottom of the Shopify Install view 
(Issue #38). 

### Problem
The "Learn More" button has a hardcoded light-gray background (`#F5F6F9`). When the application is viewed in **Dark Mode**, standard Ionic styling auto-inverts the text/icon colors to white (based on the `--ion-color-dark` variable). This resulted in invisible white text rendering over a light-gray button background, rendering it unreadable.

### Solution
I have implemented the fix for the issue by making the styling changes directly in the ShopifyInstall.vue component!

**Changes Made:**
1. Wrapped the specific .ion-item-button color styling inside an @media (prefers-color-scheme: dark) media query to ensure the styling is strictly applied only in dark mode.
2. Used var(--ion-color-dark-contrast) which automatically evaluates to black (#000000) in dark mode, successfully adhering to the preferred dynamic variable schema from variables.css.
3. The "Learn More about connecting HotWax Commerce to Shopify" title text will now remain readable in black while in dark mode using the exact CSS variable pattern you preferred.


### Refers to
Refers to #38

### Testing Details
1. Navigated to the Shopify installation UI (`/shopify-install`).
2. Toggled system settings to **Dark Mode** / forced theme classes.
3. Verified that both the text and book icon successfully rendered in solid black on top of the light button.
